### PR TITLE
Proportional load

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 [compat]
 DataFrames = "1"
 JuMP = "1"
-PowerNetworkMatrices = "0.7.1"
-PowerSystems = "2.1"
+PowerNetworkMatrices = "^0.7.1"
+PowerSystems = "^2.2"
 julia = "1"

--- a/examples/rts/rts-interface-demo.jl
+++ b/examples/rts/rts-interface-demo.jl
@@ -17,7 +17,8 @@ set_units_base_system!(sys, "natural_units")
 @time interface_lims = find_interface_limits(sys, solver);
 
 @info "calculating n-0 interface limits with ptdf rounding"
-@time interface_lims = find_interface_limits(sys, solver, ptdf = VirtualPTDF(sys, tol = 10e-3))
+@time interface_lims =
+    find_interface_limits(sys, solver, ptdf = VirtualPTDF(sys, tol = 10e-3))
 
 @info "calculating n-0 interface limits with single problem"
 @time interface_lims = find_monolithic_interface_limits(sys, solver);


### PR DESCRIPTION
Thought: in 0.1.0 injections are unbounded except for gen buses > 0 and load buses < 0.
This approach allows for a mostly state independent assessment of ITL. However, it could be unrealistic in 2 ways:

1. injections could exceed installed capabilities (gen or load) - this is intentional to preserve (capacity) state independence
2. load injections are uncorrelated

We can certainly improve on 2 by adding a constraint to make loads maintain a proportional
withdraw.