### PR TITLE
injection constraints

### DIFF
--- a/examples/rts/rts-interface-demo.jl
+++ b/examples/rts/rts-interface-demo.jl
@@ -38,3 +38,13 @@ interface = interfaces[interface_key]
     interface,
     security = true,
 );
+
+# Example with custom injection limits
+@time interface_lims = find_interface_limits(
+    sys,
+    solver,
+    interface_key,
+    interface,
+    security = true,
+    injection_limits = InjectionLimits(genbus_upper_bound=5.0, loadbus_bounds=(0.0,2.0), enforce_ldfs=true),
+);

--- a/examples/rts/rts-interface-demo.jl
+++ b/examples/rts/rts-interface-demo.jl
@@ -26,16 +26,15 @@ interface_lims = find_interface_limits(sys, solver, security = true);
 
 
 @info "calculating n-0 interface limits for just 1 interface"
-interfaces = find_interfaces(sys)
+interfaces = InterfaceLimits.find_interfaces(sys)
 interface_key = first(collect(keys(interfaces)))
 interface = interfaces[interface_key]
 @time interface_lims =
-    find_interface_limits(sys, solver, interface_key, interface, interfaces);
+    find_interface_limits(sys, solver, interface_key, interface);
 @time interface_lims = find_interface_limits(
     sys,
     solver,
     interface_key,
     interface,
-    interfaces,
     security = true,
 );

--- a/src/InterfaceLimits.jl
+++ b/src/InterfaceLimits.jl
@@ -300,7 +300,7 @@ function add_variables!(
     @variable(m, P[inames, get_name.(union(gen_buses, load_buses, hvdc_buses))])
     vars = Dict{String,Any}("flow" => F, "interface" => I, "injection" => P)
     if injection_limits.enforce_ldfs
-        @variable(m, L) # constrain later
+        @variable(m, L[inames]) # constrain in add_constraints!
         vars["load"] = L
     end
     if isa(security, Security)
@@ -392,8 +392,8 @@ function add_constraints!(
     total_load, ldf = find_ldfs(sys, load_buses)
     if injection_limits.enforce_ldfs
         L = vars["load"]
-        @constraint(m, L >= -injection_limits.loadbus_bounds[2] * total_load)
-        @constraint(m, L <= -injection_limits.loadbus_bounds[1] * total_load)
+        @constraint(m, L .≥ -injection_limits.loadbus_bounds[2] * total_load)
+        @constraint(m, L .≤ -injection_limits.loadbus_bounds[1] * total_load)
     end
 
     if isa(security, Security)
@@ -444,7 +444,7 @@ function add_constraints!(
             if b in load_buses
                 bus_ldf = ldf[bus_name]
                 if injection_limits.enforce_ldfs
-                    load_lim = bus_ldf * L
+                    load_lim = bus_ldf * L[iname]
                 else
                     bus_peak_load = -bus_ldf * total_load
                     load_lim = (injection_limits.loadbus_bounds[1]*bus_peak_load, 

--- a/src/InterfaceLimits.jl
+++ b/src/InterfaceLimits.jl
@@ -522,11 +522,11 @@ function find_load_buses(sys, bus_neighbors)
 end
 
 function get_peak_load(load::ElectricLoad)
-    return get_max_active_power(load)
+    return max(0.0, get_max_active_power(load))
 end
 
 function get_peak_load(load::FixedAdmittance)
-    return real(get_base_voltage(get_bus(load))^2 * get_Y(load))
+    return max(0.0, real(get_base_voltage(get_bus(load))^2 * get_Y(load)))
 end
 
 function find_ldfs(sys, load_buses)
@@ -653,7 +653,7 @@ function find_interface_limits(
     inames = join.(roundtrip_ikey, "_")
 
     # Build a JuMP Model
-    m = direct_model(solver)
+    m = Model(solver)
     # set_attribute(m, "BarHomogeneous", 1)
     vars = add_variables!(
         m,

--- a/src/InterfaceLimits.jl
+++ b/src/InterfaceLimits.jl
@@ -549,7 +549,6 @@ Calculates the bi-directional interface transfer limits for each interface in a 
 - `solver::JuMP.MOI.OptimizerWithAttributes` : Solver
 - `interface_key::Pair{String, String}` :  key to select single interface (optional arg to run calculation for single interface)
 - `interface::Vector{ACBranch}` : vector of branches included in interface (optional arg to run calculation for single interface)
-- `interfaces::Dict{Pair{String, String}, Vector{ACBranch}}` : dict of all interfaces (optional arg to run calculation for single interface)
 
 # Keyword Arguments
 
@@ -557,8 +556,6 @@ Calculates the bi-directional interface transfer limits for each interface in a 
 - `ptdf::VirtualPTDF = VirtualPTDF(sys),` : power transfer distribution factor matrix
 - `security::Union{Bool, Security} = false` : enforce n-1 transmission security constraints
 - `injection_limits::InjectionLimits = InjectionLimits()` : constrain generation and load injections
-- `enforce_gen_limits::Bool = false` : enforce generator capacity limits defined by available generators in System
-- `enforce_load_distribution::Bool = false` : enforce constant load distribution factor constraints
 - `hops::Int = 3` : topological distance to include neighboring (outside of interface regions) transmission lines in interface transfer limit calculations
 
 # Examples
@@ -585,7 +582,7 @@ interface_lims = find_interface_limits(sys, solver, branch_filter = bf);
 interfaces = InterfaceLimits.find_interfaces(sys)
 interface_key = first(collect(keys(interfaces)))
 interface = interfaces[interface_key]
-interface_lims = find_interface_limits(sys, solver, interface_key, interface, interfaces);
+interface_lims = find_interface_limits(sys, solver, interface_key, interface);
 ```
 """
 


### PR DESCRIPTION
Changes how injections can be constrained - can now impose upper and lower limits on generators and loads, in addition to enforcing load distribution factors. 